### PR TITLE
VEGA-1852 Make header navigation links customisable #minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,19 @@ Add dependency to package.json in repo you want to import it into `"opg-sirius-h
 Import the SCSS from sirius-header into the repo's main.scss file `@import "node_modules/opg-sirius-header/sass/sirius-header"` <br>
 Import module into repo's main.js file `import "opg-sirius-header/sirius-header.js"` <br>
 Run `Yarn install` and build the CSS locally
+
+To incorporate the header into a page, use this HTML:
+
+```
+<sirius-header></sirius-header>
+```
+
+This inserts a header with the default Sirius Supervision links in the primary navigation. These links can be customised
+with `<sirius-header-nav>` elements as follows:
+
+```
+<sirius-header>
+    <sirius-header-nav url="/lpa">Case list</sirius-header-nav>
+    <sirius-header-nav url="/another/path">Another link</sirius-header-nav>
+</sirius-header>
+```

--- a/cypress/e2e/header.cy.js
+++ b/cypress/e2e/header.cy.js
@@ -93,4 +93,35 @@ describe("header spec", () => {
       },
     });
   });
+
+  it("can be customised with sirius-header-nav elements", () => {
+    cy.visit("/lpa");
+    let linkTextContents = [];
+
+    const navList = cy.get(".moj-primary-navigation__link").each((item) => {
+      linkTextContents.push(item.text().trim());
+    }).then(() => {
+      cy.wrap(linkTextContents).should("eql", ["Case list", "Another nav item"]);
+    });
+  });
+
+  it("meets accessibility standards", () => {
+    cy.visit("/index.html");
+    cy.injectAxe();
+    cy.checkA11y(null, {
+      rules: {
+        "landmark-one-main": { enabled: false },
+        "page-has-heading-one": { enabled: false },
+      },
+    });
+
+    cy.visit("/lpa");
+    cy.injectAxe();
+    cy.checkA11y(null, {
+      rules: {
+        "landmark-one-main": { enabled: false },
+        "page-has-heading-one": { enabled: false },
+      },
+    });
+  });
 });

--- a/public/lpa/index.html
+++ b/public/lpa/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script type="module" src="../../js/sirius-header.js"></script>
+  <link rel="stylesheet" href="../../css/all.css">
+  <title>Sirius Header</title>
+</head>
+<body class="govuk-template__body">
+  <sirius-header>
+    <sirius-header-nav url="/lpa">Case list</sirius-header-nav>
+    <sirius-header-nav url="/supervision">Another nav item</sirius-header-nav>
+  </sirius-header>
+</body>
+</html>

--- a/sirius-header.js
+++ b/sirius-header.js
@@ -10,7 +10,15 @@ export class SiriusHeader extends HTMLElement {
       "Finance Manager",
     ].some((r) => userRoles.includes(r));
 
-    const navLinks = [
+    /* Default nav links for Sirius Supervision; can be overridden
+     * by defining <sirius-header-nav url="/path/to/resource" hide="true">Text for link</sirius-header-nav>
+     * elements inside the <sirius-header> element.
+     *
+     * Note that you shouldn't mix the show-finance attribute with
+     * custom <sirius-header-nav> elements, as the child elements
+     * can define their own hide attribute.
+     */
+    let navLinks = [
       {
         url: "/supervision/#/clients/search-for-client",
         title: "Create client"
@@ -30,6 +38,21 @@ export class SiriusHeader extends HTMLElement {
         hide: !isFinanceUser,
       },
     ];
+
+    // Override the nav links if <sirius-header-nav> elements are defined
+    // inside the <sirius-header>.
+    const navElements = this.querySelectorAll('sirius-header-nav');
+    if (navElements.length > 0) {
+        navLinks = [];
+
+        navElements.forEach((navElement) => {
+            navLinks.push({
+                url: navElement.getAttribute('url'),
+                hide: navElement.getAttribute('hide') === 'true',
+                title: navElement.textContent,
+            });
+        });
+    }
 
     this.innerHTML = `  
             <div class="sirius-header">         

--- a/sirius-header.js
+++ b/sirius-header.js
@@ -10,14 +10,6 @@ export class SiriusHeader extends HTMLElement {
       "Finance Manager",
     ].some((r) => userRoles.includes(r));
 
-    /* Default nav links for Sirius Supervision; can be overridden
-     * by defining <sirius-header-nav url="/path/to/resource" hide="true">Text for link</sirius-header-nav>
-     * elements inside the <sirius-header> element.
-     *
-     * Note that you shouldn't mix the show-finance attribute with
-     * custom <sirius-header-nav> elements, as the child elements
-     * can define their own hide attribute.
-     */
     let navLinks = [
       {
         url: "/supervision/#/clients/search-for-client",
@@ -40,7 +32,7 @@ export class SiriusHeader extends HTMLElement {
     ];
 
     // Override the nav links if <sirius-header-nav> elements are defined
-    // inside the <sirius-header>.
+    // inside the <sirius-header>
     const navElements = this.querySelectorAll('sirius-header-nav');
     if (navElements.length > 0) {
         navLinks = [];


### PR DESCRIPTION
This PR allows the `<sirius-header>` custom element to be customised via child elements:

```
<sirius-header>
  <sirius-header-nav url="/lpa">Case list</sirius-header-nav>
  <sirius-header-nav url="/supervision">Another nav item</sirius-header-nav>
</sirius-header>
```

The default is still to show the Sirius Supervision navigation items, so this change is backwards-compatible.

This makes it possible to use the header for the LPA service, where the sub-menu navigation elements are different.